### PR TITLE
fix(django-process_expired): add django container by name to allowed_hosts in local dev env

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -11,7 +11,7 @@ SECRET_KEY = env(
     default="BmZnn8FeNFdaeCod8ky6eBNpTiwO45NzlFyA6kk1xo0g4Mc263gAyscHFCMCeJAi",
 )
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1"]
+ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1", "django"]
 
 # CACHES
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
It was still working, but showing lots of scary looking errors when we ran process_expired without that.