### PR TITLE
fix(expiration): change to use DRF's request object parsing instead of django's

### DIFF
--- a/scram/route_manager/api/views.py
+++ b/scram/route_manager/api/views.py
@@ -44,7 +44,7 @@ class EntryViewSet(viewsets.ModelViewSet):
         actiontype = serializer.validated_data["actiontype"]
         route = serializer.validated_data["route"]
         comment = serializer.validated_data["comment"]
-        tmp_exp = self.request.POST.get("expiration", "")
+        tmp_exp = self.request.data.get("expiration", "")
 
         try:
             expiration = parse_datetime(tmp_exp)  # noqa: F841


### PR DESCRIPTION
when testing entries with curl i realized we were just using the default expiration for everything. this update actually grabs the correct expiration. 

see https://www.django-rest-framework.org/api-guide/requests/ as to why the DRF object parsing is better as well.