### PR TITLE
hotfix(wui): Fix broken add entry from WUI

### DIFF
--- a/scram/route_manager/tests/acceptance/features/remove_ip.feature
+++ b/scram/route_manager/tests/acceptance/features/remove_ip.feature
@@ -2,7 +2,7 @@ Feature: remove a network
   Users can remove a v4 and v6 network
 
   Scenario: unauthenticated users get a 403
-    Given a client with block authorization
+    Given a client without block authorization
     When we add the entry 127.0.0.1
     Then we get a 403 status code
 
@@ -16,15 +16,10 @@ Feature: remove a network
       | 1         |
       | 9.9.9.9   |
 
-
-  Scenario Outline: removing an existing IP returns a 204
+  Scenario: removing an existing IP returns a 204
     Given a client with block authorization
     When we're logged in
-    And we add the entry <IP>
-    And we remove the entry <IP>
+    And we add the entry 1.2.3.4/32
+    And we remove the entry 1.2.3.4/32
     Then we get a 204 status code
     And the number of entrys is 0
-
-    Examples: IP
-      | PK | IP            |
-      | 1  | 1.2.3.4/32    |

--- a/scram/route_manager/tests/test_api.py
+++ b/scram/route_manager/tests/test_api.py
@@ -93,12 +93,20 @@ class TestUnauthenticatedAccess(APITestCase):
         self.ignore_url = reverse("api:v1:ignoreentry-list")
 
     def test_unauthenticated_users_have_no_create_access(self):
-        response = self.client.post(self.entry_url, {"entry": "1.2.3.4"}, format="json")
+        response = self.client.post(
+            self.entry_url,
+            {
+                "route": "1.2.3.4",
+                "comment": "test",
+                "uuid": "0e7e1cbd-7d73-4968-bc4b-ce3265dc2fd3",
+            },
+            format="json",
+        )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_unauthenticated_users_have_no_ignore_create_access(self):
         response = self.client.post(
-            self.ignore_url, {"entry": "1.2.3.4"}, format="json"
+            self.ignore_url, {"route": "1.2.3.4"}, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 

--- a/scram/route_manager/views.py
+++ b/scram/route_manager/views.py
@@ -1,7 +1,5 @@
 import ipaddress
 import json
-import logging
-import uuid
 
 import rest_framework.utils.serializer_helpers
 from channels.layers import get_channel_layer
@@ -19,7 +17,7 @@ from django.views.generic import DetailView, ListView
 
 from ..route_manager.api.views import EntryViewSet
 from ..users.models import User
-from .models import ActionType, Client, Entry
+from .models import ActionType, Entry
 
 channel_layer = get_channel_layer()
 
@@ -37,14 +35,6 @@ def home_page(request, prefilter=Entry.objects.all()):
             "objs": queryset[:num_entries],
             "total": queryset.count(),
         }
-
-    # Autocreate webUI client if it doesn't already exist
-    if not Client.objects.filter(hostname="Web Client").exists():
-        web_client = Client.objects.create(
-            hostname="Web Client", uuid=uuid.uuid4(), is_authorized=True
-        )
-        web_client.authorized_actiontypes.set([1])
-        logging.info("Created local web client")
 
     if settings.AUTOCREATE_ADMIN:
         if User.objects.count() == 0:

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,3 +32,4 @@ plugins =
 
 [behave]
 paths = scram/route_manager/tests/acceptance
+stderr_capture = no


### PR DESCRIPTION
This restores the ability to add entries from the WUI. The logic is changed to check for either a valid client UUID or a user with the proper permissions set. 

As a side effect, there's no reason to add a web client upon initialization of the app anymore, so that bit is also removed.