### PR TITLE
Hotfix/v6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,11 +96,12 @@ exec: docker-compose.yaml
 help: Makefile
 	@sed -n 's/^##//p' $<
 
+# TODO: When we move to flowspec this -a flag with change
 ## list-routes: list gobgp routes
 .Phony: list-routes
 list-routes: docker-compose.yaml
-	@docker-compose exec gobgp gobgp global rib
-
+	@docker-compose exec gobgp gobgp global rib -a ipv4
+	@docker-compose exec gobgp gobgp global rib -a ipv6
 
 ## tail-log: tail a docker container's logs (append CONTAINER=container_name_here)
 .Phony: tail-log

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -18,7 +18,7 @@ RUN addgroup --system django \
     && adduser --system --ingroup django django
 
 # Requirements are installed here to ensure they will be cached.
-COPY ./requirements /requirements
+COPY ./requirements/ /requirements
 RUN pip install --no-cache-dir -r /requirements/production.txt \
     && rm -rf /requirements
 

--- a/local.yml
+++ b/local.yml
@@ -90,4 +90,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 2001:0DB8::/112
+        - subnet: 0200:c0:ff:ee::/48

--- a/local.yml
+++ b/local.yml
@@ -12,6 +12,8 @@ services:
     image: scram_local_django
     depends_on:
       - postgres
+    networks:
+      default: {}
     volumes:
       - $CI_PROJECT_DIR:/app:z
       - /tmp/profile_data:/tmp/profile_data
@@ -33,6 +35,8 @@ services:
       context: .
       dockerfile: ./compose/production/postgres/Dockerfile
     image: scram_production_postgres
+    networks:
+      default: {}
     volumes:
       - local_postgres_data:/var/lib/postgresql/data:Z
       - local_postgres_data_backups:/backups:z
@@ -46,6 +50,8 @@ services:
       dockerfile: ./compose/local/docs/Dockerfile
     env_file:
       - ./.envs/.local/.django
+    networks:
+      default: {}
     volumes:
       - $CI_PROJECT_DIR/docs:/docs:z
       - $CI_PROJECT_DIR/config:/app/config:z
@@ -61,6 +67,8 @@ services:
 
   gobgp:
     image: jauderho/gobgp:v2.32.0
+    networks:
+      default: {}
     volumes:
       - $CI_PROJECT_DIR/gobgp_config:/config:z
     ports:
@@ -71,5 +79,15 @@ services:
     build:
       context: .
       dockerfile: ./compose/local/translator/Dockerfile
+    networks:
+      default: {}
     depends_on:
       - gobgp
+
+networks:
+  default:
+    enable_ipv6: true
+    ipam:
+      driver: default
+      config:
+        - subnet: 2001:0DB8::/112

--- a/production.yml
+++ b/production.yml
@@ -15,6 +15,8 @@ services:
     depends_on:
       - postgres
       - redis
+    networks:
+      default: {}
     volumes:
       - ./staticfiles:/staticfiles
     env_file:
@@ -34,6 +36,8 @@ services:
       context: .
       dockerfile: ./compose/production/postgres/Dockerfile
     image: scram_production_postgres
+    networks:
+      default: {}
     volumes:
       - production_postgres_data:/var/lib/postgresql/data:Z
       - production_postgres_data_backups:/backups:z
@@ -45,17 +49,21 @@ services:
     restart: on-failure:5
     depends_on:
       - django
+    networks:
+      default: {}
     volumes:
       - ./compose/production/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
       - /etc/scram/ssl/server.crt:/etc/ssl/server.crt
       - /etc/scram/ssl/server.key:/etc/ssl/server.key
       - ./staticfiles:/staticfiles
     ports:
-      - "0.0.0.0:80:80"
-      - "0.0.0.0:443:443"
+      - "443:443"
+      - "80:80"
 
   redis:
     image: redis:5.0
+    networks:
+      default: {}
     volumes:
       - production_redis_data:/var/lib/redis:Z
 
@@ -79,10 +87,18 @@ services:
     depends_on:
       - redis
       - gobgp
+    networks:
+      default: {}
     env_file:
       - ./.envs/.production/.translator
 
 networks:
+  default:
+    enable_ipv6: true
+    ipam:
+      driver: default
+      config:
+        - subnet: 2001:0DB8::/112
   peering:
     enable_ipv6: true
     driver: macvlan

--- a/production.yml
+++ b/production.yml
@@ -98,7 +98,7 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 2001:0DB8::/112
+        - subnet: 0200:c0:ff:ee::/48
   peering:
     enable_ipv6: true
     driver: macvlan

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,6 +14,7 @@ asgiref~=3.5.0  # https://github.com/django/asgiref
 # ------------------------------------------------------------------------------
 channels==3.0.4
 channels_redis==3.4.0
+django-redis==5.3.0
 django==3.2.13  # pyup: < 4.0  # https://www.djangoproject.com/
 git+https://github.com/grigorescu/django-grip@e584507#egg=django-grip
 django-eventstream==4.4.1 # https://github.com/fanout/django-eventstream


### PR DESCRIPTION
To account for a v6 only network we needed to make some changes/fixes:

Need to define a v6 only network in the docker compose files
Attach all the containers to that v6 network
Make sure we are listening on both v4 and v6
Allow the Makefile's target of `make list-routes` work with v4 and v6

Random fixes uncovered at the same time:
Missing django-redis pip package
Requirements file wasnt getting copied in correctly and breaking builds in some circumstances