### PR TITLE
fix(CI): compose v3 spec doesn't like `enable_ipv6: true` so we will try the suggested fix

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -14,6 +14,8 @@ services:
       - postgres
     networks:
       default: {}
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
     volumes:
       - $CI_PROJECT_DIR:/app:z
       - /tmp/profile_data:/tmp/profile_data
@@ -37,31 +39,18 @@ services:
     image: scram_production_postgres
     networks:
       default: {}
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
     volumes:
       - local_postgres_data:/var/lib/postgresql/data:Z
       - local_postgres_data_backups:/backups:z
     env_file:
       - ./.envs/.local/.postgres
 
-  docs:
-    image: scram_local_docs
-    build:
-      context: .
-      dockerfile: ./compose/local/docs/Dockerfile
-    env_file:
-      - ./.envs/.local/.django
-    networks:
-      default: {}
-    volumes:
-      - $CI_PROJECT_DIR/docs:/docs:z
-      - $CI_PROJECT_DIR/config:/app/config:z
-      - $CI_PROJECT_DIR/scram:/app/scram:z
-    ports:
-      - "7000"
-    command: /start-docs
-
   redis:
     image: redis:5.0
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
     ports:
       - "6379"
 
@@ -69,6 +58,8 @@ services:
     image: jauderho/gobgp:v2.32.0
     networks:
       default: {}
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
     volumes:
       - $CI_PROJECT_DIR/gobgp_config:/config:z
     ports:
@@ -81,12 +72,13 @@ services:
       dockerfile: ./compose/local/translator/Dockerfile
     networks:
       default: {}
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
     depends_on:
       - gobgp
 
 networks:
   default:
-    enable_ipv6: true
     ipam:
       driver: default
       config:

--- a/production.yml
+++ b/production.yml
@@ -17,6 +17,8 @@ services:
       - redis
     networks:
       default: {}
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
     volumes:
       - ./staticfiles:/staticfiles
     env_file:
@@ -38,6 +40,8 @@ services:
     image: scram_production_postgres
     networks:
       default: {}
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
     volumes:
       - production_postgres_data:/var/lib/postgresql/data:Z
       - production_postgres_data_backups:/backups:z
@@ -51,6 +55,8 @@ services:
       - django
     networks:
       default: {}
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
     volumes:
       - ./compose/production/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
       - /etc/scram/ssl/server.crt:/etc/ssl/server.crt
@@ -64,6 +70,8 @@ services:
     image: redis:5.0
     networks:
       default: {}
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
     volumes:
       - production_redis_data:/var/lib/redis:Z
 
@@ -71,6 +79,8 @@ services:
     image: jauderho/gobgp:v2.32.0
     volumes:
       - ./gobgp_config:/config:z
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
     networks:
       default: {}
       peering:
@@ -89,12 +99,13 @@ services:
       - gobgp
     networks:
       default: {}
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
     env_file:
       - ./.envs/.production/.translator
 
 networks:
   default:
-    enable_ipv6: true
     ipam:
       driver: default
       config:


### PR DESCRIPTION
Everything was working but the build would fail in CI. 

Fix taken from https://docs.docker.com/compose/compose-file/compose-file-v3/

Closes #15 