### PR TITLE
fix(v6): we DO need enable_ipv6 set to true

### DIFF
--- a/production.yml
+++ b/production.yml
@@ -106,6 +106,7 @@ services:
 
 networks:
   default:
+    enable_ipv6: true
     ipam:
       driver: default
       config:


### PR DESCRIPTION
docker compose spec says this doesnt exist on v3 of the spec but it fails in production to actually get a v6 address without this

rolling back #16