### PR TITLE
fix(Hotfix/soehlert/username): Fill out API username as well as WUI username

### DIFF
--- a/scram/route_manager/api/serializers.py
+++ b/scram/route_manager/api/serializers.py
@@ -38,7 +38,11 @@ class EntrySerializer(serializers.HyperlinkedModelSerializer):
     )
     route = rest_framework.CidrAddressField()
     actiontype = serializers.CharField(default="block")
-    who = CurrentUserDefault()
+    if CurrentUserDefault():
+        # This is set if we are calling this serializer from WUI
+        who = CurrentUserDefault()
+    else:
+        who = serializers.CharField()
     comment = serializers.CharField()
 
     class Meta:

--- a/scram/route_manager/api/views.py
+++ b/scram/route_manager/api/views.py
@@ -64,7 +64,12 @@ class EntryViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         actiontype = serializer.validated_data["actiontype"]
         route = serializer.validated_data["route"]
-
+        if self.request.user.username:
+            # This is set if our request comes through the WUI path
+            who = self.request.user.username
+        else:
+            # This is set if we pass the "who" through the json data in an API call (like from Zeek)
+            who = serializer.validated_data["who"]
         comment = serializer.validated_data["comment"]
         tmp_exp = self.request.data.get("expiration", "")
 
@@ -120,8 +125,8 @@ class EntryViewSet(viewsets.ModelViewSet):
             entry = Entry.objects.get(route__route=route, actiontype__name=actiontype)
             if expiration:
                 entry.expiration = expiration
+            entry.who = who
             entry.is_active = True
-            entry.who = self.request.user.username
             entry.comment = comment
             logging.info(f"{entry}")
             entry.save()

--- a/scram/route_manager/tests/acceptance/steps/common.py
+++ b/scram/route_manager/tests/acceptance/steps/common.py
@@ -57,6 +57,7 @@ def step_impl(context, value):
             "comment": "behave",
             # Authorized uuid
             "uuid": "0e7e1cbd-7d73-4968-bc4b-ce3265dc2fd3",
+            "who": "person",
         },
     )
 

--- a/scram/route_manager/tests/test_api.py
+++ b/scram/route_manager/tests/test_api.py
@@ -99,6 +99,7 @@ class TestUnauthenticatedAccess(APITestCase):
                 "route": "1.2.3.4",
                 "comment": "test",
                 "uuid": "0e7e1cbd-7d73-4968-bc4b-ce3265dc2fd3",
+                "who": "person",
             },
             format="json",
         )


### PR DESCRIPTION
We were silently dropping the username from the json data in API calls. This meant records coming from automated tools (eg Zeek) were not attributed to anyone. This fixes that while still automatically reading the logged in user from the WUI if an entry is added that way.

Also had to update tests to use the API correctly.