### PR TITLE
fix(v6): allow for a real v6 network inside the docker network

### DIFF
--- a/production.yml
+++ b/production.yml
@@ -109,7 +109,7 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 0200:c0:ff:ee::/48
+        - subnet: ${SCRAM_INTERNAL_V6_SUBNET}
   peering:
     enable_ipv6: true
     driver: macvlan


### PR DESCRIPTION
Need a routable v6 address inside the containers if we want to talk on a v6 only network and not rely on 6to4. Variablizing this allows for setting it via the .env file