### PR TITLE
refactor(docker compose plugin): Move to using the docker compose plugin

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ flake8:
 
 pytest:
   stage: test
-  image: docker/24.0.6-dind
+  image: docker:24.0.6-dind
   services:
   - docker:dind
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ flake8:
 
 pytest:
   stage: test
-  image: docker/compose:latest
+  image: docker/24.0.6-dind
   services:
   - docker:dind
   before_script:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,24 +4,22 @@ fail_fast: true
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
 
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 23.9.1
     hooks:
       - id: black
 
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
     hooks:
       - id: flake8
-        args: ['--config=setup.cfg']
-        additional_dependencies: [flake8-isort]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-.DEFAULT_GOAL := help
-
 ## toggle-prod: configure make to use the production stack
 .Phony: toggle-prod
 toggle-prod:
@@ -21,28 +19,28 @@ docker-compose.yaml:
 ## behave-all: runs behave inside the containers against all of your features
 .Phony: behave-all
 behave-all: docker-compose.yaml
-	@docker-compose run django coverage run -a manage.py behave --no-input --simple
+	@docker compose run django coverage run -a manage.py behave --no-input --simple
 
 ## behave: runs behave inside the containers against a specific feature (append FEATURE=feature_name_here)
 .Phony: behave
 behave: docker-compose.yaml
-	@docker-compose run django python manage.py behave --no-input --simple -i $(FEATURE)
+	@docker compose run django python manage.py behave --no-input --simple -i $(FEATURE)
 
 ## behave-translator
 .Phony: behave-translator
 behave-translator: docker-compose.yaml
-	@docker-compose exec -T translator /usr/local/bin/behave /app/acceptance/features
+	@docker compose exec -T translator /usr/local/bin/behave /app/acceptance/features
 
 ## build: rebuilds all your containers or a single one if CONTAINER is specified
 .Phony: build
 build: docker-compose.yaml
-	@docker-compose up -d --no-deps --build $(CONTAINER)
-	@docker-compose restart $(CONTAINER)
+	@docker compose up -d --no-deps --build $(CONTAINER)
+	@docker compose restart $(CONTAINER)
 
 ## coverage.xml: generate coverage from test runs
 coverage.xml: pytest behave-all behave-translator
-	@docker-compose run django coverage report
-	@docker-compose run django coverage xml
+	@docker compose run django coverage report
+	@docker compose run django coverage xml
 
 ## ci-test: runs all tests just like Gitlab CI does
 .Phony: ci-test
@@ -51,24 +49,18 @@ ci-test: | toggle-local build migrate run coverage.xml
 ## cleanup: remove local containers and volumes
 .Phony: clean
 clean: docker-compose.yaml
-	@docker-compose rm -f -s
+	@docker compose rm -f -s
 	@docker volume prune -f
 
 ## collect-static: run collect static admin command
 .Phony: collectstatic
 collectstatic: docker-compose.yaml
-	@docker-compose run django python manage.py collectstatic
-
-## copy: copy files over to staging server for testing (append STAGING=staging_host_here)
-# This is faster than using tower to push things out and it still keeps changes being made locally instead of remote
-.Phony: copy
-copy:
-	rsync -rl ./scram/* $(STAGING):/usr/local/scram/scram/m.
+	@docker compose run django python manage.py collectstatic
 
 ## django-addr: get the IP and ephemeral port assigned to docker:8000
 .Phony: django-addr
 django-addr: docker-compose.yaml
-	@docker-compose port django 8000
+	@docker compose port django 8000
 
 ## django-url: get the URL based on http://$(make django-addr)
 .Phony: django-url
@@ -83,13 +75,12 @@ django-open: docker-compose.yaml
 ## down: turn down docker compose stack
 .Phony: down
 down: docker-compose.yaml
-	@docker-compose down
+	@docker compose down
 
 ## exec: executes a given command on a given container (append CONTAINER=container_name_here and COMMAND=command_here)
 .Phony: exec
 exec: docker-compose.yaml
-	@docker-compose exec $(CONTAINER) $(COMMAND)
-
+	@docker compose
 # This automatically builds the help target based on commands prepended with a double hashbang
 ## help: print this help output
 .Phony: help
@@ -100,41 +91,41 @@ help: Makefile
 ## list-routes: list gobgp routes
 .Phony: list-routes
 list-routes: docker-compose.yaml
-	@docker-compose exec gobgp gobgp global rib -a ipv4
-	@docker-compose exec gobgp gobgp global rib -a ipv6
-
-## tail-log: tail a docker container's logs (append CONTAINER=container_name_here)
-.Phony: tail-log
-tail-log: docker-compose.yaml
-	@docker-compose logs -f $(CONTAINER)
+	@docker compose exec gobgp gobgp global rib -a ipv4
+	@docker compose exec gobgp gobgp global rib -a ipv6
 
 ## migrate: makemigrations and then migrate
 .Phony: migrate
 migrate: docker-compose.yaml
-	@docker-compose run django python manage.py makemigrations
-	@docker-compose run django python manage.py migrate
-
-## pytest: runs pytest inside the containers
-.Phony: pytest
-pytest: docker-compose.yaml
-	@docker-compose run django coverage run -m pytest
-
-## run: brings up the containers as described in docker-compose.yaml
-.Phony: run
-run: docker-compose.yaml
-	@docker-compose up -d
-
-## stop: turns off running containers
-.Phony: stop
-stop: docker-compose.yaml
-	@docker-compose stop
-
-## type-check: static type checking
-.Phony: type-check
-type-check: docker-compose.yaml
-	@docker-compose run django mypy scram
+	@docker compose run django python manage.py makemigrations
+	@docker compose run django python manage.py migrate
 
 ## pass-reset: change admin's password
 .Phony: pass-reset
 pass-reset: docker-compose.yaml
-	@docker-compose run django python manage.py changepassword admin
+	@docker compose run django python manage.py changepassword admin
+
+## pytest: runs pytest inside the containers
+.Phony: pytest
+pytest: docker-compose.yaml
+	@docker compose run django coverage run -m pytest
+
+## run: brings up the containers as described in docker-compose.yaml
+.Phony: run
+run: docker-compose.yaml
+	@docker compose up -d
+
+## stop: turns off running containers
+.Phony: stop
+stop: docker-compose.yaml
+	@docker compose stop
+
+## tail-log: tail a docker container's logs (append CONTAINER=container_name_here)
+.Phony: tail-log
+tail-log: docker-compose.yaml
+	@docker compose logs -f $(CONTAINER)
+
+## type-check: static type checking
+.Phony: type-check
+type-check: docker-compose.yaml
+	@docker compose run django mypy scram

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL := help
+
 ## toggle-prod: configure make to use the production stack
 .Phony: toggle-prod
 toggle-prod:
@@ -80,7 +82,8 @@ down: docker-compose.yaml
 ## exec: executes a given command on a given container (append CONTAINER=container_name_here and COMMAND=command_here)
 .Phony: exec
 exec: docker-compose.yaml
-	@docker compose
+	@docker compose exec $(CONTAINER) $(COMMAND)
+
 # This automatically builds the help target based on commands prepended with a double hashbang
 ## help: print this help output
 .Phony: help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,103 @@
+# ==== pytest ====
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--ds=config.settings.test --reuse-db"
+python_files = [
+    "tests.py",
+    "test_*.py",
+]
+
+# ==== Coverage ====
+[tool.coverage.run]
+omit = ["*/migrations/*", "*/tests/*"]
+plugins = ["django_coverage_plugin"]
+
+
+# ==== black ====
+[tool.black]
+line-length = 119
+target-version = ['py311']
+
+
+# ==== isort ====
+[tool.isort]
+profile = "black"
+line_length = 119
+known_first_party = [
+    "scram",
+    "config",
+]
+skip = ["venv/"]
+skip_glob = ["**/migrations/*.py"]
+
+
+# ==== mypy ====
+[tool.mypy]
+python_version = "3.11"
+check_untyped_defs = true
+ignore_missing_imports = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_unused_configs = true
+plugins = [
+    "mypy_django_plugin.main",
+    "mypy_drf_plugin.main",
+]
+
+[[tool.mypy.overrides]]
+# Django migrations should not produce any errors:
+module = "*.migrations.*"
+ignore_errors = true
+
+[tool.django-stubs]
+django_settings_module = "config.settings.test"
+
+
+# ==== PyLint ====
+[tool.pylint.MASTER]
+load-plugins = [
+    "pylint_django",
+]
+django-settings-module = "config.settings.local"
+
+[tool.pylint.FORMAT]
+max-line-length = 119
+
+[tool.pylint."MESSAGES CONTROL"]
+disable = [
+    "missing-docstring",
+    "invalid-name",
+]
+
+[tool.pylint.DESIGN]
+max-parents = 13
+
+[tool.pylint.TYPECHECK]
+generated-members = [
+    "REQUEST",
+    "acl_users",
+    "aq_parent",
+    "[a-zA-Z]+_set{1,2}",
+    "save",
+    "delete",
+]
+
+
+# ==== djLint ====
+[tool.djlint]
+blank_line_after_tag = "load,extends"
+close_void_tags = true
+format_css = true
+format_js = true
+# TODO: remove T002 when fixed https://github.com/Riverside-Healthcare/djLint/issues/687
+ignore = "H006,H021,H023,H025,H029,H030,H031,T002,T003"
+include = "H017,H035"
+indent = 2
+max_line_length = 119
+profile = "django"
+
+[tool.djlint.css]
+indent_size = 2
+
+[tool.djlint.js]
+indent_size = 2


### PR DESCRIPTION
Standalone docker compose v1 we were using is deprecated. By updating the Makefile we can point to the right commands and continue to use the same Make targets in dev and via ansible deployment. Updating the .gitlab-ci.yml file to use a different image should get CI using the same version of docker compose as well.

Reordered the Makefile as well for easier understanding. Also removed an extraneous target that wasn't doing anything or working.

precommit and pyproject.toml changes were because precommit was failing not allowing any commits. These changes get it working again so we can continue committing the actual changes.