### PR TITLE
fix(compose): v6 network had host bits in it

### DIFF
--- a/compose.override.local.yml
+++ b/compose.override.local.yml
@@ -61,4 +61,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 0200:c0:ff:ee::/48
+        - subnet: 0200:c0:ff:ee::/64

--- a/compose.override.production.yml
+++ b/compose.override.production.yml
@@ -72,7 +72,7 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 0200:c0:ff:ee::/48
+        - subnet: 0200:c0:ff:ee::/64
   peering:
     enable_ipv6: true
     driver: macvlan


### PR DESCRIPTION
We don't need a /48 anyways for the intracontainer network so lets just do a /64.