### PR TITLE
Hotfix/asn community

### DIFF
--- a/translator/gobgp.py
+++ b/translator/gobgp.py
@@ -83,12 +83,23 @@ class GoBGP(object):
         as_path.Pack(as_segments)
 
         # Set our community number
+        # Large community: attribute is a set of one or more 12-byte values,
+        # each of which is in the format of Global Administrator:LocalData1:LocalData2
+        #
+        # global_admin = The Global Administrator field is intended to represent a complete 4-byte ASN
+        # local_data* is for more flexible routing policy. can be set to ME:ACTION:YOU or ASN:Function:Parameter.
+        #
+        # Use local_data2 for any "flag" you want to send to the router that can be used for routing policy decisions.
         communities = Any()
-        try:
-            comm_id = (asn << 16) + community
-            communities.Pack(attribute_pb2.CommunitiesAttribute(communities=[comm_id]))
-        except ValueError:
-            logging.warning(f"Community {comm_id} too large to use; please pick a smaller ASN and try again")
+        global_admin = asn
+        local_data1 = community
+        local_data2 = 0
+        large_community = attribute_pb2.LargeCommunity(
+            global_admin=global_admin,
+            local_data1=local_data1,
+            local_data2=local_data2,
+        )
+        communities.Pack(attribute_pb2.LargeCommunitiesAttribute(communities=[large_community]))
 
         attributes = [origin, next_hop, as_path, communities]
 

--- a/translator/gobgp.py
+++ b/translator/gobgp.py
@@ -84,7 +84,11 @@ class GoBGP(object):
 
         # Set our community number
         communities = Any()
-        communities.Pack(attribute_pb2.CommunitiesAttribute(communities=[community]))
+        try:
+            comm_id = (asn << 16) + community
+            communities.Pack(attribute_pb2.CommunitiesAttribute(communities=[comm_id]))
+        except ValueError:
+            logging.warning(f"Community {comm_id} too large to use; please pick a smaller ASN and try again")
 
         attributes = [origin, next_hop, as_path, communities]
 

--- a/translator/gobgp.py
+++ b/translator/gobgp.py
@@ -96,7 +96,7 @@ class GoBGP(object):
             # local_data* is for more flexible routing policy. can be set to ME:ACTION:YOU or ASN:Function:Parameter.
             #
             # Use local_data2 for any "flag" you want to send to the router to be used for routing policy decisions.
-            logging.warning(f"LargeCommunity Used - ASN:{asn} Community: {community}")
+            logging.info(f"LargeCommunity Used - ASN:{asn} Community: {community}")
             global_admin = asn
             local_data1 = community
             local_data2 = 0

--- a/translator/gobgp.py
+++ b/translator/gobgp.py
@@ -91,14 +91,10 @@ class GoBGP(object):
             comm_id = (asn << 16) + community
             communities.Pack(attribute_pb2.CommunitiesAttribute(communities=[comm_id]))
         else:
-            # Large Community: 3 fields of 4 bytes version of a community string
-            # global_admin = The Global Administrator field is intended to represent a complete 4-byte ASN
-            # local_data* is for more flexible routing policy. can be set to ME:ACTION:YOU or ASN:Function:Parameter.
-            #
-            # Use local_data2 for any "flag" you want to send to the router to be used for routing policy decisions.
             logging.info(f"LargeCommunity Used - ASN:{asn} Community: {community}")
             global_admin = asn
             local_data1 = community
+            # set to 0 because there's no use case for it, but we need a local_data2 for gobgp to read any of it
             local_data2 = 0
             large_community = attribute_pb2.LargeCommunity(
                 global_admin=global_admin,

--- a/translator/gobgp.py
+++ b/translator/gobgp.py
@@ -83,9 +83,6 @@ class GoBGP(object):
         as_path.Pack(as_segments)
 
         # Set our community number
-        # Large community: attribute is a set of one or more 12-byte values,
-        # each of which is in the format of Global Administrator:LocalData1:LocalData2
-        #
         # global_admin = The Global Administrator field is intended to represent a complete 4-byte ASN
         # local_data* is for more flexible routing policy. can be set to ME:ACTION:YOU or ASN:Function:Parameter.
         #


### PR DESCRIPTION
We need to pass our ASN inside the community, having them separate doesn't work for us. For example, we need to see  `123:666` 

That said, it was just as easy to add Large Community support so we didn't end up in a spot where the ASN and Community were variables, but could overflow the structure with valid variable choices. I need to talk to our network engineers to see if they can support the Large Community as this does:

   Network              Next Hop             AS_PATH              Age        Attrs
*> 1.1.1.1/32           192.0.2.199          65400                00:08:31   [{Origin: ?} {LargeCommunity: [ 65400:666:0]}]

If we can't support that right now, it would be easy enough to add in standard community support in some sort of if/then. Maybe based on a binary being set in the web socket message of `Largecommunities: True` or `Largecommunities: False` and then we can pull from that like we do ASN and Community already.