### PR TITLE
fix(translator-consumer): make the translator consumer use websocketmessage dict

### DIFF
--- a/config/consumers.py
+++ b/config/consumers.py
@@ -20,6 +20,7 @@ class TranslatorConsumer(AsyncJsonWebsocketConsumer):
             WebSocketSequenceElement.objects.filter(action_type__name=self.actiontype).order_by("order_num")
         )
         if not elements:
+            logging.warning(f"No elements found for actiontype={self.actiontype}.")
             return
 
         # Avoid lazy evaluation

--- a/config/consumers.py
+++ b/config/consumers.py
@@ -20,7 +20,7 @@ class TranslatorConsumer(AsyncJsonWebsocketConsumer):
             WebSocketSequenceElement.objects.filter(action_type__name=self.actiontype).order_by("order_num")
         )
         if not elements:
-            logging.warning(f"No elements found for actiontype={self.actiontype}.")
+            return
 
         # Avoid lazy evaluation
         routes = await sync_to_async(list)(Entry.objects.filter(is_active=True).values_list("route__route", flat=True))


### PR DESCRIPTION
This should make sure routes learned from another instance with a shared postgres backend get announced with the proper values set in websocketmessage dict. also fixes that for when translator gets restarted. it used to use the default asn/community in those cases