### PR TITLE
fix: Force django CPU Arch to explicitly be x86

### DIFF
--- a/compose.override.local.yml
+++ b/compose.override.local.yml
@@ -1,5 +1,5 @@
 ---
-version: '3.4'
+version: "3.4"
 
 volumes:
   local_postgres_data: {}
@@ -7,6 +7,7 @@ volumes:
 
 services:
   django:
+    platform: linux/amd64
     build:
       dockerfile: ./compose/local/django/Dockerfile
     image: scram_local_django


### PR DESCRIPTION
I can't say with certainty why, however, running our tests locally on an Apple Silicon device causes the tests to fail sporadically, specifically in `test_websockets.py`. It has ✨something✨ to do with running on Apple Silicon, but I'm not sure what. As a workaround, if you specify the `django` container to use  `platform: linux/amd64` then your container runtime will pipe it through rosetta, it will run as x86 and all will be happy. This works on a fresh install of docker desktop with no configuration changes.

I've tested this on both colima and docker desktop and it works like a charm. With this set, I don't ever get test failures, with it unset, I will always have some number of test failures in `test_websockets.py`. 

I don't think there are any downsides to leaving this platform value set other than perhaps some slightly increased resource usage on an Apple Silicon Mac when running the containers. To me, that tradeoff seems worth it to be able to run tests locally, but if desired, we could make this some sort of variable that is only running when we run tests. 

I still think we should get to the bottom of **why** this is happening, but for now, this is a convenient workaround IMO.