### PR TITLE
fix(postgres_container): Don't spin up a postgres container in prod by default

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,8 @@ pytest:
   image: docker:24.0.6-dind
   services:
   - docker:dind
+  variables:
+    POSTGRES_ENABLED: 1
   before_script:
   - apk add make
   - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY

--- a/compose.override.production.yml
+++ b/compose.override.production.yml
@@ -27,6 +27,8 @@ services:
       - production_postgres_data_backups:/backups:z
     env_file:
       - ./.envs/.production/.postgres
+    deploy:
+      replicas: 0
 
   nginx:
     image: nginx:1.19

--- a/compose.yml
+++ b/compose.yml
@@ -32,6 +32,8 @@ services:
       - net.ipv6.conf.all.disable_ipv6=0
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
+    deploy:
+      replicas: ${POSTGRES_ENABLED:-0}
 
   redis:
     image: redis:5.0
@@ -64,4 +66,3 @@ services:
       default: {}
     sysctls:
       - net.ipv6.conf.all.disable_ipv6=0
-


### PR DESCRIPTION
This also gives the option to set an envvar to set one or more postgres containers in prod if someone wants. this allows us to keep using a separate postgres instance by default without having to manually change files on servers.