### PR TITLE
fix: ci issues related to recent changes

### DIFF
--- a/.idea/runConfigurations/Django_Debugger.xml
+++ b/.idea/runConfigurations/Django_Debugger.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Django Debugger" type="PyRemoteDebugConfigurationType" factoryName="Python Remote Debug">
     <module name="scram" />
-    <option name="PORT" value="3003" />
+    <option name="PORT" value="56783" />
     <option name="HOST" value="0.0.0.0" />
     <PathMappingSettings>
       <option name="pathMappings">

--- a/.idea/runConfigurations/Translator_Debugger.xml
+++ b/.idea/runConfigurations/Translator_Debugger.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Translator Debugger" type="PyRemoteDebugConfigurationType" factoryName="Python Remote Debug">
     <module name="scram" />
-    <option name="PORT" value="3002" />
+    <option name="PORT" value="56782" />
     <option name="HOST" value="0.0.0.0" />
     <PathMappingSettings>
       <option name="pathMappings">

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "attach",
             "connect": {
                 "host": "0.0.0.0",
-                "port": 3000
+                "port": 56780
             },
             "pathMappings": [
                 {
@@ -25,7 +25,7 @@
             "request": "attach",
             "connect": {
                 "host": "0.0.0.0",
-                "port": 3001
+                "port": 56781
             },
             "pathMappings": [
                 {

--- a/compose.override.local.yml
+++ b/compose.override.local.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.4"
 
 volumes:
   local_postgres_data: {}
@@ -32,6 +31,8 @@ services:
       - local_postgres_data_backups:/backups:z
     env_file:
       - ./.envs/.local/.postgres
+    deploy:
+      replicas: ${POSTGRES_ENABLED:-1}
 
   docs:
     image: scram_local_docs

--- a/compose.override.local.yml
+++ b/compose.override.local.yml
@@ -21,10 +21,10 @@ services:
       test: ["CMD", "curl", "-f", "http://django:8000/process_expired/"]
     ports:
       - "8000"
-      - 3000:3000
+      - 56780:56780
     environment:
       # This can be set to either `debugpy` or `pycharm-pydevd` currently.
-      - DEBUG=${DEBUG}
+      - DEBUG=${DEBUG:-}
 
   postgres:
     volumes:
@@ -65,10 +65,10 @@ services:
     volumes:
       - ./translator/tests/:/app/tests/
     ports:
-      - 3001:3001
+      - 56781:56781
     environment:
       # This can be set to either `debugpy` or `pycharm-pydevd` currently.
-      - DEBUG=${DEBUG}
+      - DEBUG=${DEBUG:-}
 
 networks:
   default:

--- a/compose.override.production.yml
+++ b/compose.override.production.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.4'
 
 volumes:
   production_postgres_data: {}

--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.4'
 
 services:
   django:

--- a/config/asgi.py
+++ b/config/asgi.py
@@ -27,7 +27,7 @@ if debug_mode:
 
         import pydevd_pycharm
 
-        pydevd_pycharm.settrace("host.docker.internal", port=3003, stdoutToServer=True, stderrToServer=True)
+        pydevd_pycharm.settrace("host.docker.internal", port=56783, stdoutToServer=True, stderrToServer=True)
 
         logging.info("Debugger started.")
     elif debug_mode == "debugpy":
@@ -35,9 +35,9 @@ if debug_mode:
 
         import debugpy
 
-        debugpy.listen(("0.0.0.0", 3000))
+        debugpy.listen(("0.0.0.0", 56780))
 
-        logging.info("Debugger listening on port 3000.")
+        logging.info("Debugger listening on port 56780.")
     else:
         logging.warning(f"Invalid debug mode given: {debug_mode}. Debugger not started")
 

--- a/translator/translator.py
+++ b/translator/translator.py
@@ -36,7 +36,7 @@ if debug_mode:
 
         import pydevd_pycharm
 
-        pydevd_pycharm.settrace("host.docker.internal", port=3002, stdoutToServer=True, stderrToServer=True)
+        pydevd_pycharm.settrace("host.docker.internal", port=56782, stdoutToServer=True, stderrToServer=True)
 
         logging.info("Debugger started.")
     elif debug_mode == "debugpy":
@@ -46,9 +46,9 @@ if debug_mode:
 
         import debugpy
 
-        debugpy.listen(("0.0.0.0", 3001))
+        debugpy.listen(("0.0.0.0", 56781))
 
-        logging.info("Debugger listening on port 3001.")
+        logging.info("Debugger listening on port 56781.")
     else:
         logging.warning(f"Invalid debug mode given: {debug_mode}. Debugger not started")
 


### PR DESCRIPTION
Some small cosmetic changes here are that I set the debug variable to be empty by default to supress any errors in docker compose and any unnecessary warning log. I also got rid of the version in the compose files too because that was getting really old hearing compose yell about the deprecated flag. 

This mainly though fixes the CI issues introduced by both the debugger and the postgres replica changes.  For the former, we make sure we're on a port that's not already in use by the gitlab runners, and for the latter, we ensure that for the local compose profile we default our postgres replicas for 1.

Whoopsie!


Sorry for the mix-and-match MR, can break it apart if we care.