### PR TITLE
fix(settings.py): Include docker containers in django ALLOWED_HOSTS

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -8,7 +8,7 @@ from .base import AUTHENTICATION_BACKENDS, MIDDLEWARE, env
 # https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
 SECRET_KEY = env("DJANGO_SECRET_KEY")
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = env("DJANGO_ALLOWED_HOSTS", default=["es.net"])
+ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["django", "nginx"])
 
 # DATABASES
 # ------------------------------------------------------------------------------

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -8,7 +8,7 @@ from .base import AUTHENTICATION_BACKENDS, MIDDLEWARE, env
 # https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
 SECRET_KEY = env("DJANGO_SECRET_KEY")
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["django", "nginx"])
+ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["django"])
 
 # DATABASES
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Django ALLOWED_HOSTS (in production) needs to be set in your SCRAM install to allow connections from the django container (for docker compose healthcheck) and the hostname of your actual server (for nginx proxied traffic, like a user hitting the WUI, API calls, etc). So for a typical SCRAM server deployed to production at `scram.example.com` you would need `ALLOWED_HOSTS` to be set to `ALLOWED_HOSTS = ["django", "scram.example.com"]`. 

This uses the `django-environ` list type casting to take the `DJANGO_ALLOWED_HOSTS` env var and set it to the correct value, for example setting the env var on the system with `export DJANGO_ALLOWED_HOSTS=django,scram.example.com` would result in this in the python settings: `ALLOWED_HOSTS = ["django", "scram.example.com"]`