### PR TITLE
ci(docs): only build docs on main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Build sphinx docs
 on:
   push:
     branches:
-      - '**'
+      - 'main'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This hopefully fixes our CI errors we are seeing. When we do our next release, we should double check to make sure they actually build though.