### PR TITLE
feat(active_blocks): Add a quick way to tell how many active blocks there are

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -19,6 +19,8 @@ services:
       timeout: 30s
       start_period: 30s
       retries: 5
+    deploy:
+      replicas: ${DJANGO_REPLICAS:-1}
 
   postgres:
     build:
@@ -51,6 +53,8 @@ services:
       - net.ipv6.conf.all.disable_ipv6=0
     healthcheck:
       test: ["CMD", "gobgp", "global"]
+    deploy:
+      replicas: ${GOBGP_REPLICAS:-1}
 
   translator:
     build:
@@ -65,3 +69,5 @@ services:
       default: {}
     sysctls:
       - net.ipv6.conf.all.disable_ipv6=0
+    deploy:
+      replicas: ${TRANSLATOR_REPLICAS:-1}

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -186,6 +186,7 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "scram.utils.context_processors.settings_context",
                 "scram.route_manager.context_processors.login_logout",
+                "scram.route_manager.context_processors.active_count",
             ],
         },
     },

--- a/scram/route_manager/context_processors.py
+++ b/scram/route_manager/context_processors.py
@@ -17,12 +17,14 @@ def login_logout(request):
     return {"login": login_url, "logout": logout_url}
 
 
-def active_count(request):
+def active_count(request, *args, **kwargs):
     """Grab the active count of blocks.
 
     Returns:
         dict: active count of blocks
     """
-    active_block_entries = Entry.objects.filter(is_active=True).count()
-    total_block_entries = Entry.objects.all().count()
-    return {"active_block_entries": active_block_entries, "total_block_entries": total_block_entries}
+    if "admin" not in request.META["PATH_INFO"]:
+        active_block_entries = Entry.objects.filter(is_active=True).count()
+        total_block_entries = Entry.objects.all().count()
+        return {"active_block_entries": active_block_entries, "total_block_entries": total_block_entries}
+    return {}

--- a/scram/route_manager/context_processors.py
+++ b/scram/route_manager/context_processors.py
@@ -3,6 +3,8 @@
 from django.conf import settings
 from django.urls import reverse
 
+from scram.route_manager.models import Entry
+
 
 def login_logout(request):
     """Pass through the relevant URLs from the settings.
@@ -13,3 +15,14 @@ def login_logout(request):
     login_url = reverse(settings.LOGIN_URL)
     logout_url = reverse(settings.LOGOUT_URL)
     return {"login": login_url, "logout": logout_url}
+
+
+def active_count(request):
+    """Grab the active count of blocks.
+
+    Returns:
+        dict: active count of blocks
+    """
+    active_block_entries = Entry.objects.filter(is_active=True).count()
+    total_block_entries = Entry.objects.all().count()
+    return {"active_block_entries": active_block_entries, "total_block_entries": total_block_entries}

--- a/scram/route_manager/context_processors.py
+++ b/scram/route_manager/context_processors.py
@@ -17,7 +17,7 @@ def login_logout(request):
     return {"login": login_url, "logout": logout_url}
 
 
-def active_count(request, *args, **kwargs):
+def active_count(request):
     """Grab the active count of blocks.
 
     Returns:

--- a/scram/route_manager/tests/test_performance.py
+++ b/scram/route_manager/tests/test_performance.py
@@ -36,15 +36,14 @@ class TestViewNumQueries(TestCase):
         2. lookup session
         3. lookup user
         4. filter available actiontypes
-        5. count entries with actiontype=1
-        6. count entries with actiontype=1 and is_active
-        7. count by user
-        8. context processor active_count active blocks
-        9. context processor active_count all blocks
-        10. first page for actiontype=1
-        11. close transaction
+        5. count entries with actiontype=1 and is_active
+        6. count by user
+        7. context processor active_count active blocks
+        8. context processor active_count all blocks
+        9. first page for actiontype=1
+        10. close transaction
         """
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(10):
             start = time.time()
             self.client.get(reverse("route_manager:home"))
             time_taken = time.time() - start

--- a/scram/route_manager/tests/test_performance.py
+++ b/scram/route_manager/tests/test_performance.py
@@ -30,26 +30,28 @@ class TestViewNumQueries(TestCase):
         Entry.objects.bulk_create(entries)
 
     def test_home_page(self):
-        """Home page requires 8 queries.
+        """Home page requires 11 queries.
 
         1. create transaction
         2. lookup session
         3. lookup user
         4. filter available actiontypes
         5. count entries with actiontype=1
-        6. count by user
-        7. first page for actiontype=1
-        8. close transaction
-
+        6. count entries with actiontype=1 and is_active
+        7. count by user
+        8. context processor active_count active blocks
+        9. context processor active_count all blocks
+        10. first page for actiontype=1
+        11. close transaction
         """
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(11):
             start = time.time()
             self.client.get(reverse("route_manager:home"))
             time_taken = time.time() - start
             self.assertLess(time_taken, 1, "Home page took longer than 1 second")
 
     def test_entry_view(self):
-        """Viewing an entry requires 6 queries.
+        """Viewing an entry requires 8 queries.
 
         1. create transaction savepoint
         2. lookup session
@@ -57,9 +59,10 @@ class TestViewNumQueries(TestCase):
         4. get entry
         5. rollback to savepoint
         6. release transaction savepoint
-
+        7. context processor active_count active blocks
+        8. context processor active_count all blocks
         """
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(8):
             start = time.time()
             self.client.get(reverse("route_manager:detail", kwargs={"pk": 9999}))
             time_taken = time.time() - start

--- a/scram/route_manager/tests/test_performance.py
+++ b/scram/route_manager/tests/test_performance.py
@@ -26,7 +26,7 @@ class TestViewNumQueries(TestCase):
         self.atype, _ = ActionType.objects.get_or_create(name="block")
         routes = [Route(route=self.fake.unique.ipv4_public()) for x in range(self.NUM_ENTRIES)]
         created_routes = Route.objects.bulk_create(routes)
-        entries = [Entry(route=route, actiontype=self.atype) for route in created_routes]
+        entries = [Entry(route=route, actiontype=self.atype, is_active=True) for route in created_routes]
         Entry.objects.bulk_create(entries)
 
     def test_home_page(self):

--- a/scram/route_manager/views.py
+++ b/scram/route_manager/views.py
@@ -35,11 +35,9 @@ def home_page(request, prefilter=None):
         readwrite = False
     context = {"entries": {}, "readwrite": readwrite}
     for at in ActionType.objects.all():
-        queryset = prefilter.filter(actiontype=at).order_by("-pk")
-        queryset_active = queryset.filter(is_active=True).order_by("-pk")
+        queryset_active = prefilter.filter(actiontype=at, is_active=True)
         context["entries"][at] = {
             "objs": queryset_active[:num_entries],
-            "total": queryset.count(),
             "active": queryset_active.count(),
         }
 

--- a/scram/route_manager/views.py
+++ b/scram/route_manager/views.py
@@ -36,9 +36,11 @@ def home_page(request, prefilter=None):
     context = {"entries": {}, "readwrite": readwrite}
     for at in ActionType.objects.all():
         queryset = prefilter.filter(actiontype=at).order_by("-pk")
+        queryset_active = queryset.filter(is_active=True).order_by("-pk")
         context["entries"][at] = {
-            "objs": queryset[:num_entries],
+            "objs": queryset.filter(is_active=True)[:num_entries],
             "total": queryset.count(),
+            "active": queryset_active.count(),
         }
 
     if settings.AUTOCREATE_ADMIN:

--- a/scram/route_manager/views.py
+++ b/scram/route_manager/views.py
@@ -38,7 +38,7 @@ def home_page(request, prefilter=None):
         queryset = prefilter.filter(actiontype=at).order_by("-pk")
         queryset_active = queryset.filter(is_active=True).order_by("-pk")
         context["entries"][at] = {
-            "objs": queryset.filter(is_active=True)[:num_entries],
+            "objs": queryset_active[:num_entries],
             "total": queryset.count(),
             "active": queryset_active.count(),
         }

--- a/scram/templates/navbar.html
+++ b/scram/templates/navbar.html
@@ -27,6 +27,9 @@
           <li class="nav-item d-inline mt-2">
             <a id="account-home" class="nav-link" href="{% url 'users:detail' user.username %}">{{ user.name }}</a>
           </li>
+          <li class="nav-item d-inline mt-3">
+            <span class="badge badge-info badge-pill" style="background-color:#2ba6c8!important;">Blocks:<br>{{ active_block_entries }}</span>
+          </li>
           <li class="nav-item mt-2 d-inline">
              <form action="{{ logout }}" method="post">
                {% csrf_token %}
@@ -34,6 +37,9 @@
              </form>
           </li>
         {% else %}
+            <li class="nav-item d-inline mt-3">
+              <span class="badge badge-info badge-pill" style="background-color:#2ba6c8!important;">Blocks:<br>{{ active_block_entries }}</span>
+            </li>
            <li class="nav-item mt-2 d-inline">
             <a class="btn btn-outline-info ml-2 mb-2" style="color:#2ba6c8!important;" role="button" href="{{ login }}">Login</a>          </li>
         {% endif %}

--- a/scram/templates/route_manager/home.html
+++ b/scram/templates/route_manager/home.html
@@ -35,7 +35,7 @@
       <div class="col">
         {% if actiontype.available %}
         <h2 class="text-center mt-2">{{ actiontype.name }}
-          <span class="badge badge-secondary badge-pill">{{ entry_list.total }}</span>
+          <span class="badge badge-secondary badge-pill">{{ entry_list.active }}</span>
         </h2>
           {% for entry in entry_list.objs %}
             {% if actiontype.name|lower == entry.actiontype|lower %}


### PR DESCRIPTION
Closes #30

This adds a pill badge to the navbar with a quick view at active blocks. Also, it filters the homepage to only show active blocks and update the pill badge above the actiontype list on the homepage to only show the count of active blocks. The navbar is specific to blocks, but that seems fair since 1) that's the main use case right now 2) that's the only default actiontype anyways. We can always make it nicer/configurable in the future if needed.