### PR TITLE
fix(add_form): redirect to the homepage after adding via the form on the home page

### DIFF
--- a/scram/route_manager/tests/test_authorization.py
+++ b/scram/route_manager/tests/test_authorization.py
@@ -95,7 +95,7 @@ class AuthzTest(TestCase):
                     "uuid": "0e7e1cbd-7d73-4968-bc4b-ce3265dc2fd3",
                 },
             )
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 302)
 
     def test_unauthorized_detail_view(self):
         """Ensure that unauthorized users can't view the blocked IPs."""
@@ -124,7 +124,7 @@ class AuthzTest(TestCase):
 
         self.client.force_login(test_user)
         response = self.client.post(reverse("route_manager:add"), {"route": "192.0.2.4/32", "actiontype": "block"})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 302)
 
         test_user.groups.set([])
 

--- a/scram/route_manager/views.py
+++ b/scram/route_manager/views.py
@@ -124,8 +124,8 @@ def add_entry(request):
     else:
         messages.add_message(request, messages.WARNING, f"Something went wrong: {res.status_code}")
     with transaction.atomic():
-        home = home_page(request)
-    return home  # noqa RET504
+        home_page(request)
+    return redirect("route_manager:home")
 
 
 def process_expired(request):


### PR DESCRIPTION
Closes #113 

This was an annoying UX bug where you would be on a url ending in `/add` meaning you couldn't refresh or anything since it's a POST only endpoint. This way things are still added, but now you are redirected to the actual home page. 