### PR TITLE
feat(translator): slap a variable on log level (and default to INFO)

### DIFF
--- a/.envs/.local/.translator
+++ b/.envs/.local/.translator
@@ -3,3 +3,4 @@
 TRANSLATOR_HOSTNAME = localhost
 TRANSLATOR_URL = "ws://django:8000/ws/route_manager/translator_block/"
 SCRAM_HOSTNAME = "localhost"
+LOG_LEVEL = "DEBUG"

--- a/translator/gobgp.py
+++ b/translator/gobgp.py
@@ -19,7 +19,6 @@ MAX_SMALL_ASN = 2**16
 MAX_SMALL_COMM = 2**16
 IPV6 = 6
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 

--- a/translator/translator.py
+++ b/translator/translator.py
@@ -7,10 +7,14 @@ import ipaddress
 import json
 import logging
 import os
+from os import getenv
 
 import websockets
 from gobgp import GoBGP
 
+LOG_LEVEL = getenv("LOG_LEVEL", "INFO")
+
+logging.basicConfig(level=LOG_LEVEL)
 logger = logging.getLogger(__name__)
 
 KNOWN_MESSAGES = {


### PR DESCRIPTION
It's time for the downfall of DEBUG level logging. Long live INFO level logging. To change this in translator, change the "LOGGING_LEVEL" env var for the translator container to DEBUG, INFO, etc. 