### PR TITLE
fix(API username change): Issue from the pentest report

### DIFF
--- a/scram/users/api/views.py
+++ b/scram/users/api/views.py
@@ -3,7 +3,7 @@
 from django.contrib.auth import get_user_model
 from rest_framework import status
 from rest_framework.decorators import action
-from rest_framework.mixins import ListModelMixin, RetrieveModelMixin, UpdateModelMixin
+from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
@@ -12,7 +12,7 @@ from .serializers import UserSerializer
 User = get_user_model()
 
 
-class UserViewSet(RetrieveModelMixin, ListModelMixin, UpdateModelMixin, GenericViewSet):
+class UserViewSet(RetrieveModelMixin, ListModelMixin, GenericViewSet):
     """Lookup Users by username."""
 
     serializer_class = UserSerializer


### PR DESCRIPTION
Remove the ability to change your own username from the API. This was pointed out in the pentest we had done :

> The Users API found at ~/api/v1/users/<USER_NAME>/ allows for a user to change their username to one that doesn't exist. This doesn't have any major implications, however, it is unintended functionality that should be removed. As an example, if a user were to change their username to “Admïn,” a person could be fooled into thinking it was another user doing the changes. 