### PR TITLE
ci(build): Be like the cool kids and use `uv`

### DIFF
--- a/.ci-scripts/flake8_before.sh
+++ b/.ci-scripts/flake8_before.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-uv pip install -q flake8
+uv pip install --system -q flake8

--- a/.ci-scripts/flake8_before.sh
+++ b/.ci-scripts/flake8_before.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-pip install -q flake8
+uv pip install -q flake8

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -60,9 +60,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements/local.txt
+          python -m pip install uv
+          uv pip install -r requirements/local.txt
           # https://github.com/pytest-dev/pytest-github-actions-annotate-failures/pull/68 isn't yet in a release
-          pip install git+https://github.com/pytest-dev/pytest-github-actions-annotate-failures.git@6e66cd895fe05cd09be8bad58f5d79110a20385f
+          uv pip install git+https://github.com/pytest-dev/pytest-github-actions-annotate-failures.git@6e66cd895fe05cd09be8bad58f5d79110a20385f
 
       - name: Apply migrations
         env:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -61,9 +61,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install uv
-          uv pip install -r requirements/local.txt
+          uv pip install --system -r requirements/local.txt
           # https://github.com/pytest-dev/pytest-github-actions-annotate-failures/pull/68 isn't yet in a release
-          uv pip install git+https://github.com/pytest-dev/pytest-github-actions-annotate-failures.git@6e66cd895fe05cd09be8bad58f5d79110a20385f
+          uv pip install --system git+https://github.com/pytest-dev/pytest-github-actions-annotate-failures.git@6e66cd895fe05cd09be8bad58f5d79110a20385f
 
       - name: Apply migrations
         env:

--- a/.github/workflows/pytest_next_python.yml
+++ b/.github/workflows/pytest_next_python.yml
@@ -54,9 +54,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements/local.txt
+          python -m pip install uv
+          uv pip install -r requirements/local.txt
           # https://github.com/pytest-dev/pytest-github-actions-annotate-failures/pull/68 isn't yet in a release
-          pip install git+https://github.com/pytest-dev/pytest-github-actions-annotate-failures.git@6e66cd895fe05cd09be8bad58f5d79110a20385f
+          uv pip install git+https://github.com/pytest-dev/pytest-github-actions-annotate-failures.git@6e66cd895fe05cd09be8bad58f5d79110a20385f
 
       - name: Apply unapplied migrations
         env:

--- a/.github/workflows/pytest_next_python.yml
+++ b/.github/workflows/pytest_next_python.yml
@@ -55,9 +55,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install uv
-          uv pip install -r requirements/local.txt
+          uv pip install --system -r requirements/local.txt
           # https://github.com/pytest-dev/pytest-github-actions-annotate-failures/pull/68 isn't yet in a release
-          uv pip install git+https://github.com/pytest-dev/pytest-github-actions-annotate-failures.git@6e66cd895fe05cd09be8bad58f5d79110a20385f
+          uv pip install --system git+https://github.com/pytest-dev/pytest-github-actions-annotate-failures.git@6e66cd895fe05cd09be8bad58f5d79110a20385f
 
       - name: Apply unapplied migrations
         env:

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update \
 
 # Requirements are installed here to ensure they will be cached.
 COPY ./requirements /requirements
-RUN pip install -r /requirements/local.txt
+RUN pip install uv
+RUN uv pip install -r /requirements/local.txt
 
 COPY ./compose/production/django/entrypoint /entrypoint
 RUN sed -i 's/\r$//g' /entrypoint

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
 # Requirements are installed here to ensure they will be cached.
 COPY ./requirements /requirements
 RUN pip install uv
-RUN uv pip install -r /requirements/local.txt
+RUN uv pip install --system -r /requirements/local.txt
 
 COPY ./compose/production/django/entrypoint /entrypoint
 RUN sed -i 's/\r$//g' /entrypoint

--- a/compose/local/docs/Dockerfile
+++ b/compose/local/docs/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
 # Only re-run the pip install if these files have changed
 COPY requirements/base.txt requirements/local.txt requirements/production.txt /app/requirements/
 RUN pip install uv
-RUN uv pip install -r /app/requirements/local.txt -r /app/requirements/production.txt
+RUN uv pip install --system -r /app/requirements/local.txt -r /app/requirements/production.txt
 
 COPY . /app/
 

--- a/compose/local/docs/Dockerfile
+++ b/compose/local/docs/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update \
 
 # Only re-run the pip install if these files have changed
 COPY requirements/base.txt requirements/local.txt requirements/production.txt /app/requirements/
-RUN pip install -r /app/requirements/local.txt -r /app/requirements/production.txt
+RUN pip install uv
+RUN uv pip install -r /app/requirements/local.txt -r /app/requirements/production.txt
 
 COPY . /app/
 

--- a/compose/local/translator/Dockerfile
+++ b/compose/local/translator/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update \
 
 # Requirements are installed here to ensure they will be cached.
 COPY ./translator/requirements /requirements
-RUN pip install -r /requirements/base.txt
+RUN pip install uv
+RUN uv pip install -r /requirements/base.txt
 
 RUN mkdir /app \
   && cd /app \

--- a/compose/local/translator/Dockerfile
+++ b/compose/local/translator/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
 # Requirements are installed here to ensure they will be cached.
 COPY ./translator/requirements /requirements
 RUN pip install uv
-RUN uv pip install -r /requirements/base.txt
+RUN uv pip install --system -r /requirements/base.txt
 
 RUN mkdir /app \
   && cd /app \

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -22,7 +22,8 @@ RUN addgroup --system django \
 
 # Requirements are installed here to ensure they will be cached.
 COPY ./requirements/ /requirements
-RUN pip install --no-cache-dir -r /requirements/production.txt \
+RUN pip install uv
+RUN uv pip install --no-cache-dir -r /requirements/production.txt \
     && rm -rf /requirements
 
 COPY --chown=django:django ./compose/production/django/entrypoint /entrypoint

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -23,7 +23,7 @@ RUN addgroup --system django \
 # Requirements are installed here to ensure they will be cached.
 COPY ./requirements/ /requirements
 RUN pip install uv
-RUN uv pip install --no-cache-dir -r /requirements/production.txt \
+RUN uv pip install --system --no-cache-dir -r /requirements/production.txt \
     && rm -rf /requirements
 
 COPY --chown=django:django ./compose/production/django/entrypoint /entrypoint


### PR DESCRIPTION
For now, let's just use the pip compatibility layer for `uv`. 

https://docs.astral.sh/uv/pip/