### PR TITLE
fix(search): Gracefully handle ValueErrors with search

### DIFF
--- a/scram/route_manager/tests/acceptance/environment.py
+++ b/scram/route_manager/tests/acceptance/environment.py
@@ -1,5 +1,6 @@
 """Setup the environment for tests."""
 
+from django.test import Client
 from rest_framework.test import APIClient
 
 from scram.users.tests.factories import UserFactory
@@ -12,3 +13,4 @@ def django_ready(context):
 
     # Default to using the API client.
     context.test.client = APIClient()
+    context.test.web_client = Client()

--- a/scram/route_manager/tests/acceptance/features/query.feature
+++ b/scram/route_manager/tests/acceptance/features/query.feature
@@ -37,13 +37,27 @@ Feature: we can query the list of entries for a specific entry
       | 2001:DB8:950C::/48   | 2001:DB8:950C::1/128 |
       | 2001:DB8:950D::/48   | 2001:DB8:950D::1/64  |
 
+  # This is to make sure the code path for deactivating an entry works correctly
+  Scenario Outline: we cant query larger than our prefix min
+    Given a client with block authorization
+    When we're logged in
+    And the CIDR prefix limits are 24 and 48
+    And we add the entry <ip>
+    And the CIDR prefix limits are 32 and 128
+    And we query for <ip>
+    Then we get a 400 status code
 
-  Scenario Outline: we cant query for malformed IPs and get redirected back to the home page
+    Examples: IPs
+      | ip            |
+      | 192.0.2.0/24  |
+      | 2001:DB8::/48 |
+
+  Scenario Outline: we cant search malformed IPs and get redirected to the home page
     Given a client with block authorization
     When we're logged in
     And  we add the entry <ip>
     And  we query for <ip>
-    Then we get a 200 status code
+    Then we get a ValueError
 
     Examples: IPs
       | ip              |
@@ -51,4 +65,3 @@ Feature: we can query the list of entries for a specific entry
       | 193.168.0.0/33  |
       | 2001:::::       |
       | 201::0/129      |
-      | gibberish_ip    |

--- a/scram/route_manager/tests/acceptance/features/query.feature
+++ b/scram/route_manager/tests/acceptance/features/query.feature
@@ -52,7 +52,7 @@ Feature: we can query the list of entries for a specific entry
       | 192.0.2.0/24  |
       | 2001:DB8::/48 |
 
-  Scenario Outline: we cant search malformed IPs and get redirected to the home page
+  Scenario Outline: we get the proper error when querying an invalid cidr
     Given a client with block authorization
     When we're logged in
     And  we add the entry <ip>

--- a/scram/route_manager/tests/acceptance/features/query.feature
+++ b/scram/route_manager/tests/acceptance/features/query.feature
@@ -37,28 +37,13 @@ Feature: we can query the list of entries for a specific entry
       | 2001:DB8:950C::/48   | 2001:DB8:950C::1/128 |
       | 2001:DB8:950D::/48   | 2001:DB8:950D::1/64  |
 
-  Scenario Outline: we cant query larger than our prefixmin
-    Given a client with block authorization
-    When we're logged in
-    And the CIDR prefix limits are 24 and 48
-    And we add the entry <ip>
-    And the CIDR prefix limits are 32 and 128
-    And we query for <ip>
-    Then we get a 400 status code
 
-
-    Examples: IPs
-      | ip            |
-      | 192.0.2.0/24  |
-      | 2001:DB8::/48 |
-
-  Scenario Outline: we cant enter malformed IPs
+  Scenario Outline: we cant query for malformed IPs and get redirected back to the home page
     Given a client with block authorization
     When we're logged in
     And  we add the entry <ip>
     And  we query for <ip>
-    Then we get a ValueError
-
+    Then we get a 200 status code
 
     Examples: IPs
       | ip              |
@@ -66,3 +51,4 @@ Feature: we can query the list of entries for a specific entry
       | 193.168.0.0/33  |
       | 2001:::::       |
       | 201::0/129      |
+      | gibberish_ip    |

--- a/scram/route_manager/tests/acceptance/features/search.feature
+++ b/scram/route_manager/tests/acceptance/features/search.feature
@@ -1,7 +1,7 @@
 Feature: Test our search bar
   We need to make sure search works as expected
 
-  Scenario Outline: Searching for a valid CIDR works even with prepending white space
+  Scenario Outline: Searching for a valid CIDR works
     Given a client with block authorization
     When we're logged in
     And we add the entry <ip>
@@ -13,7 +13,7 @@ Feature: Test our search bar
     | 192.0.2.168        |
     | 2001:DB8:9508::1   |
 
-  Scenario Outline: Searching for an invalid CIDR redirects to the home page and sends a 400
+  Scenario Outline: Searching for an invalid CIDR sends a 400
     Given a client with block authorization
     When we're logged in
     And we search for <ip>

--- a/scram/route_manager/tests/acceptance/features/search.feature
+++ b/scram/route_manager/tests/acceptance/features/search.feature
@@ -13,7 +13,7 @@ Feature: Test our search bar
     | 192.0.2.168        |
     | 2001:DB8:9508::1   |
 
-  Scenario Outline: Searching for an invalid CIDR sends a 400
+  Scenario Outline: Searching for an invalid CIDR returns a Bad Request error
     Given a client with block authorization
     When we're logged in
     And we search for <ip>

--- a/scram/route_manager/tests/acceptance/features/search.feature
+++ b/scram/route_manager/tests/acceptance/features/search.feature
@@ -1,0 +1,25 @@
+Feature: Test our search bar
+  We need to make sure search works as expected
+
+  Scenario Outline: Searching for a valid CIDR works even with prepending white space
+    Given a client with block authorization
+    When we're logged in
+    And we add the entry <ip>
+    And we search for <ip>
+    Then we get a 200 status code
+
+    Examples: IPs
+    | ip                 |
+    | 192.0.2.168        |
+    | 2001:DB8:9508::1   |
+
+  Scenario Outline: Searching for an invalid CIDR redirects to the home page and sends a 400
+    Given a client with block authorization
+    When we're logged in
+    And we search for <ip>
+    Then we get a 400 status code
+
+  Examples: IPs
+    | ip    |
+    | " "   |
+    | asdf  |

--- a/scram/route_manager/tests/acceptance/steps/common.py
+++ b/scram/route_manager/tests/acceptance/steps/common.py
@@ -9,7 +9,12 @@ from channels.layers import get_channel_layer
 from django import conf
 from django.urls import reverse
 
-from scram.route_manager.models import ActionType, Client, WebSocketMessage, WebSocketSequenceElement
+from scram.route_manager.models import (
+    ActionType,
+    Client,
+    WebSocketMessage,
+    WebSocketSequenceElement,
+)
 
 
 @given("a {name} actiontype is defined")
@@ -54,6 +59,7 @@ def create_unauthed_client(context, name):
 def login(context):
     """Login."""
     context.test.client.login(username="user", password="password")
+    context.test.web_client.login(username="user", password="password")
 
 
 @when("the CIDR prefix limits are {v4_minprefix:d} and {v6_minprefix:d}")

--- a/scram/route_manager/tests/acceptance/steps/ip.py
+++ b/scram/route_manager/tests/acceptance/steps/ip.py
@@ -1,9 +1,12 @@
 """Define steps used for IP-related logic by the Behave tests."""
 
 import ipaddress
+import logging
 
 from behave import then, when
 from django.urls import reverse
+
+logger = logging.getLogger(__name__)
 
 
 @then("{route} is contained in our list of {model}s")
@@ -25,12 +28,8 @@ def check_route(context, route, model):
 @when("we query for {ip}")
 def check_ip(context, ip):
     """Find an Entry for the specified IP."""
-    try:
-        context.response = context.test.client.get(reverse("api:v1:entry-detail", args=[ip]))
-        context.queryException = None
-    except ValueError as e:
-        context.response = None
-        context.queryException = e
+    search_url = reverse("route_manager:search")
+    context.response = context.test.client.post(search_url, {"cidr": ip}, format="multipart", follow=True)
 
 
 @then("we get a ValueError")

--- a/scram/route_manager/tests/acceptance/steps/ip.py
+++ b/scram/route_manager/tests/acceptance/steps/ip.py
@@ -48,3 +48,12 @@ def check_comment(context, value, comment):
     except ValueError as e:
         context.response = None
         context.queryException = e
+
+
+@when("we search for {ip}")
+def search_ip(context, ip):
+    """Search our main search bar for an IP."""
+    client = context.test.web_client
+    search_url = reverse("route_manager:search")
+
+    context.response = client.post(search_url, data={"cidr": ip})

--- a/scram/route_manager/tests/acceptance/steps/ip.py
+++ b/scram/route_manager/tests/acceptance/steps/ip.py
@@ -1,12 +1,9 @@
 """Define steps used for IP-related logic by the Behave tests."""
 
 import ipaddress
-import logging
 
 from behave import then, when
 from django.urls import reverse
-
-logger = logging.getLogger(__name__)
 
 
 @then("{route} is contained in our list of {model}s")
@@ -28,8 +25,12 @@ def check_route(context, route, model):
 @when("we query for {ip}")
 def check_ip(context, ip):
     """Find an Entry for the specified IP."""
-    search_url = reverse("route_manager:search")
-    context.response = context.test.client.post(search_url, {"cidr": ip}, format="multipart", follow=True)
+    try:
+        context.response = context.test.client.get(reverse("api:v1:entry-detail", args=[ip]))
+        context.queryException = None
+    except ValueError as e:
+        context.response = None
+        context.queryException = e
 
 
 @then("we get a ValueError")

--- a/scram/route_manager/views.py
+++ b/scram/route_manager/views.py
@@ -76,7 +76,12 @@ def search_entries(request):
     # Using ipaddress because we needed to turn off strict mode
     # (which netfields uses by default with seemingly no toggle)
     # This caused searches with host bits set to 500 which is bad UX see: 68854ee1ad4789a62863083d521bddbc96ab7025
-    addr = ipaddress.ip_network(request.POST.get("cidr"), strict=False)
+    try:
+        addr = ipaddress.ip_network(request.POST.get("cidr"), strict=False)
+    except ValueError:
+        # leading space was breaking ipaddress module
+        str_addr = str(request.POST.get("cidr")).strip()
+        addr = ipaddress.ip_network(str_addr, strict=False)
     # We call home_page because search is just a more specific case of the same view and template to return.
     return home_page(
         request,

--- a/scram/route_manager/views.py
+++ b/scram/route_manager/views.py
@@ -76,6 +76,9 @@ def search_entries(request):
     # Using ipaddress because we needed to turn off strict mode
     # (which netfields uses by default with seemingly no toggle)
     # This caused searches with host bits set to 500 which is bad UX see: 68854ee1ad4789a62863083d521bddbc96ab7025
+    if request.method != "POST":
+        return redirect("route_manager:home")
+
     try:
         addr = ipaddress.ip_network(request.POST.get("cidr"), strict=False)
     except ValueError:
@@ -84,7 +87,8 @@ def search_entries(request):
             str_addr = str(request.POST.get("cidr")).strip()
             addr = ipaddress.ip_network(str_addr, strict=False)
         except ValueError:
-            messages.add_message(request, messages.ERROR, "Search query was blank")
+            messages.add_message(request, messages.ERROR, "Search query was not a valid CIDR address")
+
             return redirect("route_manager:home")
 
     # We call home_page because search is just a more specific case of the same view and template to return.

--- a/scram/route_manager/views.py
+++ b/scram/route_manager/views.py
@@ -79,9 +79,14 @@ def search_entries(request):
     try:
         addr = ipaddress.ip_network(request.POST.get("cidr"), strict=False)
     except ValueError:
-        # leading space was breaking ipaddress module
-        str_addr = str(request.POST.get("cidr")).strip()
-        addr = ipaddress.ip_network(str_addr, strict=False)
+        try:
+            # leading space was breaking ipaddress module
+            str_addr = str(request.POST.get("cidr")).strip()
+            addr = ipaddress.ip_network(str_addr, strict=False)
+        except ValueError:
+            messages.add_message(request, messages.ERROR, "Search query was blank")
+            return redirect("route_manager:home")
+
     # We call home_page because search is just a more specific case of the same view and template to return.
     return home_page(
         request,


### PR DESCRIPTION
Closes #31 

We saw a 500 ValueError for two cases:
- a search query with extraneous whitespace
- a completely blank search query