### PR TITLE
fix(ux): only show "deactivate entry" button on the entry detail page when the entry is actually active

### DIFF
--- a/scram/templates/route_manager/entry_detail.html
+++ b/scram/templates/route_manager/entry_detail.html
@@ -16,11 +16,14 @@
           <td class="text-center">{{ entry.actiontype.name }}</td>
           <td>{{ entry.expiration }}</td>
           <td class="text-center">{{ entry.is_active }}</td>
+          {% if entry.is_active %}
           <td>
-            <form class="form-inline" action="{% url 'route_manager:delete' entry.id %}" method="POST">
-            {% csrf_token %}
-            <button class="btn btn-danger btn-sm" type="submit">Deactivate Entry</button>
-            </form></td>
+              <form class="form-inline" action="{% url 'route_manager:delete' entry.id %}" method="POST">
+              {% csrf_token %}
+              <button class="btn btn-danger btn-sm" type="submit">Deactivate Entry</button>
+              </form>
+          </td>
+          {% endif %}
         </tr>
       </table>
     </div>


### PR DESCRIPTION
<img width="610" alt="Screenshot 2025-04-14 at 5 13 55 PM" src="https://github.com/user-attachments/assets/919e5b1c-9d5e-4c6d-b8fd-dff3ca67031b" />

It just seems like bad user experience to see that. 

Closes #39 