### PR TITLE
fix(route_manager history): move history update to after model save

### DIFF
--- a/scram/route_manager/api/serializers.py
+++ b/scram/route_manager/api/serializers.py
@@ -6,7 +6,6 @@ from drf_spectacular.utils import extend_schema_field
 from netfields import rest_framework
 from rest_framework import serializers
 from rest_framework.fields import CurrentUserDefault
-from simple_history.utils import update_change_reason
 
 from ..models import ActionType, Client, Entry, IgnoreEntry, Route
 
@@ -96,7 +95,6 @@ class EntrySerializer(serializers.HyperlinkedModelSerializer):
         entry_instance, _ = Entry.objects.get_or_create(route=route_instance, actiontype=actiontype_instance)
 
         logger.debug("Created entry with comment: %s", comment)
-        update_change_reason(entry_instance, comment)
 
         return entry_instance
 

--- a/scram/route_manager/api/views.py
+++ b/scram/route_manager/api/views.py
@@ -14,6 +14,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework import status, viewsets
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
+from simple_history.utils import update_change_reason
 
 from ..models import ActionType, Client, Entry, IgnoreEntry, WebSocketSequenceElement
 from .exceptions import ActiontypeNotAllowed, IgnoredRoute, PrefixTooLarge
@@ -162,6 +163,7 @@ class EntryViewSet(viewsets.ModelViewSet):
         entry.originating_scram_instance = settings.SCRAM_HOSTNAME
         logger.info("Created entry: %s", entry)
         entry.save()
+        update_change_reason(entry, comment)
 
     @staticmethod
     def find_entries(arg, active_filter=None):


### PR DESCRIPTION
We need to actually update the Entry change reason after we save the Entry model which then creates a history model for that change. Before, we were doing it in the serializer before the model is saved, which means that the query to the DB that looks for the appropriate historical_entry instance doesn't find anything because it's looking for the historical entry that hasn't been saved yet. 

This is related to #138 and actually, I think, would have fixed it, but we came at it from a different (and frankly, I guess, wrong) angle. Because update_change_reason only **_edits_** a historical entry, not create a new one, but I was originally assuming that this function call was what created the historical entry in the first place. In #138 we "fixed" this issue by making sure that the database migrations went and edited all the history to have the default value which then means we technically were editing the comment for the wrong history entry.