### PR TITLE
fix(history): Remove duplicate entries

### DIFF
--- a/scram/route_manager/api/serializers.py
+++ b/scram/route_manager/api/serializers.py
@@ -6,6 +6,8 @@ from drf_spectacular.utils import extend_schema_field
 from netfields import rest_framework
 from rest_framework import serializers
 from rest_framework.fields import CurrentUserDefault
+from simple_history.utils import update_change_reason
+
 
 from ..models import ActionType, Client, Entry, IgnoreEntry, Route
 
@@ -70,19 +72,40 @@ class EntrySerializer(serializers.HyperlinkedModelSerializer):
     originating_scram_instance = serializers.CharField(default="scram_hostname_not_set", read_only=True)
     is_active = serializers.BooleanField(default=True, read_only=True)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance is not None:
+            self.fields['route'].read_only = True
+            self.fields['actiontype'].read_only = True
+            self.fields['who'].read_only = True
+
     class Meta:
         """Maps to the Entry model, and specifies the fields exposed by the API."""
         model = Entry
         fields = ["route", "actiontype", "url", "comment", "who", "expiration", "originating_scram_instance", "is_active"]
 
-    @staticmethod
-    def get_comment(obj):
-        """Provide a nicer name for change reason.
+    def create(self, validated_data):
+        """Create or update an Entry, handling duplicates gracefully."""
+        route_data = validated_data.pop('route')
+        actiontype_name = validated_data.pop('actiontype')
+        comment = validated_data.pop('comment')
 
-        Returns:
-            string: The change reason that modified the Entry.
-        """
-        return obj.get_change_reason()
+        route_instance, _ = Route.objects.get_or_create(route=route_data)
+        actiontype_instance = ActionType.objects.get(name=actiontype_name)
+
+        entry, created = Entry.objects.get_or_create(
+            route=route_instance,
+            actiontype=actiontype_instance,
+            defaults=validated_data
+        )
+
+        if not created:
+            for key, value in validated_data.items():
+                setattr(entry, key, value)
+            entry.save()
+            update_change_reason(entry, comment)
+
+        return entry
 
 
 class IgnoreEntrySerializer(serializers.ModelSerializer):

--- a/scram/route_manager/api/serializers.py
+++ b/scram/route_manager/api/serializers.py
@@ -72,7 +72,7 @@ class EntrySerializer(serializers.HyperlinkedModelSerializer):
         """Maps to the Entry model, and specifies the fields exposed by the API."""
 
         model = Entry
-        fields = ["route", "actiontype", "url", "comment", "who"]
+        fields = ["route", "actiontype", "url", "comment", "who", "expiration", "originating_scram_instance"]
 
     @staticmethod
     def get_comment(obj):
@@ -82,21 +82,6 @@ class EntrySerializer(serializers.HyperlinkedModelSerializer):
             string: The change reason that modified the Entry.
         """
         return obj.get_change_reason()
-
-    @staticmethod
-    def create(validated_data):
-        """Implement custom logic and validates creating a new route."""
-        valid_route = validated_data.pop("route")
-        actiontype = validated_data.pop("actiontype")
-        comment = validated_data.pop("comment")
-
-        route_instance, _ = Route.objects.get_or_create(route=valid_route)
-        actiontype_instance = ActionType.objects.get(name=actiontype)
-        entry_instance, _ = Entry.objects.get_or_create(route=route_instance, actiontype=actiontype_instance)
-
-        logger.debug("Created entry with comment: %s", comment)
-
-        return entry_instance
 
 
 class IgnoreEntrySerializer(serializers.ModelSerializer):

--- a/scram/route_manager/api/serializers.py
+++ b/scram/route_manager/api/serializers.py
@@ -67,12 +67,13 @@ class EntrySerializer(serializers.HyperlinkedModelSerializer):
     else:
         who = serializers.CharField()
     comment = serializers.CharField()
+    originating_scram_instance = serializers.CharField(default="scram_hostname_not_set", read_only=True)
+    is_active = serializers.BooleanField(default=True, read_only=True)
 
     class Meta:
         """Maps to the Entry model, and specifies the fields exposed by the API."""
-
         model = Entry
-        fields = ["route", "actiontype", "url", "comment", "who", "expiration", "originating_scram_instance"]
+        fields = ["route", "actiontype", "url", "comment", "who", "expiration", "originating_scram_instance", "is_active"]
 
     @staticmethod
     def get_comment(obj):

--- a/scram/route_manager/api/views.py
+++ b/scram/route_manager/api/views.py
@@ -121,12 +121,13 @@ class EntryViewSet(viewsets.ModelViewSet):
         route_instance, _ = Route.objects.get_or_create(route=route)
         actiontype_instance = ActionType.objects.get(name=actiontype)
 
-        if self.request.user.username:
-            # This is set if our request comes through the WUI path
-            who = self.request.user.username
-        else:
+        if serializer.validated_data.get("who"):
             # This is set if we pass the "who" through the json data in an API call (like from Zeek)
             who = serializer.validated_data["who"]
+        else:
+            # This is set if our request comes through the WUI path
+            who = self.request.user.username
+
         comment = serializer.validated_data["comment"]
         tmp_exp = self.request.data.get("expiration", "")
 
@@ -165,7 +166,6 @@ class EntryViewSet(viewsets.ModelViewSet):
             is_active=True,
             comment=comment,
             originating_scram_instance=settings.SCRAM_HOSTNAME,
-            expiration=expiration if expiration else None
         )
         entry = serializer.instance
         update_change_reason(entry, comment)

--- a/scram/route_manager/tests/acceptance/features/restrict_changes.feature
+++ b/scram/route_manager/tests/acceptance/features/restrict_changes.feature
@@ -7,7 +7,7 @@ Feature: restrict changing entries
     When we're logged in
     And we add the entry 192.0.2.208
     And we update the entry 192.0.2.208 to 192.0.2.209
-    Then we get a 405 status code
+    Then we get a 403 status code
     And the number of entrys is 1
     And 192.0.2.208 is announced by block translators
     And 192.0.2.209 is not announced by block translators

--- a/scram/route_manager/views.py
+++ b/scram/route_manager/views.py
@@ -143,8 +143,6 @@ def add_entry(request):
         messages.add_message(request, messages.ERROR, "Permission Denied")
     else:
         messages.add_message(request, messages.WARNING, f"Something went wrong: {res.status_code}")
-    with transaction.atomic():
-        home_page(request)
     return redirect("route_manager:home")
 
 


### PR DESCRIPTION
Closes #9 
Closes #162 

This removes the duplicate historicalentry we saw on initial creation. This also handles the comment on updates. This did require adding an update api view and serializer. The update stuff is only available on the API at the moment, we can add an update template for the WUI later if we want (likely).

As part of this change we fixed the messages getting swallowed. Sorry I can't `git` well enough to fix that and add to another branch, but it was such a minor code change hopefully it's ok.

Also, I did figure out that the `changed_by` field shown in the admin is actually the `_historical_user` field, however, I don't think that matters. It's only a cosmetic thing in the admin panel as the API correctly shows the `who` field. Since that's the field we care about (as it's calculated both from API calls and the webUI) we can just use that field in our front end templates. 