### PR TITLE
feat(gw_priority): this should allow us to choose which network is th…

### DIFF
--- a/compose.override.production.yml
+++ b/compose.override.production.yml
@@ -80,6 +80,7 @@ services:
     networks:
       default: {}
       peering:
+        priority: 1000
         ipv4_address: ${SCRAM_V4_ADDRESS}
         ipv6_address: ${SCRAM_V6_ADDRESS}
     ports:


### PR DESCRIPTION
…e "default gateway" of the macvlan address

previously on dual connected gobgp instances, it would often respond over the docker compose network, never being able to reach its destination