### PR TITLE
fix(postgres): use new folder structure.

### DIFF
--- a/compose.override.local.yml
+++ b/compose.override.local.yml
@@ -51,7 +51,7 @@ services:
 
   postgres:
     volumes:
-      - local_postgres_data:/var/lib/postgresql/data:Z
+      - local_postgres_data:/var/lib/postgresql:Z
       - local_postgres_data_backups:/backups:z
     env_file:
       - ./.envs/.local/.postgres

--- a/compose.override.production.yml
+++ b/compose.override.production.yml
@@ -30,7 +30,7 @@ services:
       options:
           tag: scram-postgres
     volumes:
-      - production_postgres_data:/var/lib/postgresql/data:Z
+      - production_postgres_data:/var/lib/postgresql:Z
       - production_postgres_data_backups:/backups:z
     env_file:
       - ./.envs/.production/.postgres


### PR DESCRIPTION
Postgres doesn't seem to like including the data directory in v18 (or at some point from v12). This uses a different mount structure and seems to work fine locally.