### PR TITLE
fix(process_updates): process updates no matter which instance is touched

### DIFF
--- a/scram/route_manager/tests/integration/features/multi_instance_sync.feature
+++ b/scram/route_manager/tests/integration/features/multi_instance_sync.feature
@@ -51,3 +51,37 @@ Feature: Multi-Instance Synchronization
     When secondary instance runs process_updates
     Then the entry 2001:db8::30/128 is inactive on secondary instance
     And secondary announces 2001:db8::30/128 removal to block translators
+
+  Scenario: IPv4 entry expiring on primary instance is reprocessed by primary
+    Given a block actiontype is defined
+    When we create entry 192.168.100.4/32 with 3 second expiration on primary instance
+    And we wait for database commit
+    And we wait 4 seconds for expiration
+    When primary instance runs process_updates to expire entries
+    Then primary announces 192.168.100.4/32 removal to block translators
+
+  Scenario: IPv6 entry expiring on primary instance is reprocessed by primary
+    Given a block actiontype is defined
+    When we create entry 2001:db8::4/128 with 3 second expiration on primary instance
+    And we wait for database commit
+    And we wait 4 seconds for expiration
+    When primary instance runs process_updates to expire entries
+    Then primary announces 2001:db8::4/128 removal to block translators
+
+  Scenario: IPv4 entry deactivated on primary instance is reprocessed by primary
+    Given a block actiontype is defined
+    When we create an entry 192.168.100.5/32 on primary instance
+    And we wait for database commit
+    When we deactivate entry 192.168.100.5/32 on primary instance
+    And we wait for database commit
+    When primary instance runs process_updates to expire entries
+    Then primary announces 192.168.100.5/32 removal to block translators
+
+  Scenario: IPv6 entry deactivated on primary instance is reprocessed by primary
+    Given a block actiontype is defined
+    When we create an entry 2001:db8::5/128 on primary instance
+    And we wait for database commit
+    When we deactivate entry 2001:db8::5/128 on primary instance
+    And we wait for database commit
+    When primary instance runs process_updates to expire entries
+    Then primary announces 2001:db8::5/128 removal to block translators

--- a/scram/route_manager/views.py
+++ b/scram/route_manager/views.py
@@ -187,18 +187,12 @@ def check_for_orphaned_history(recently_touched_ids: set[int], entries_to_proces
 
     Args:
         recently_touched_ids(set): Set of Entry IDs that have recent history records.
-        entries_to_process(list): Entry objects fetched from the database (excludes local instance).
+        entries_to_process(list): Entry objects fetched from the database.
     """
-    # IDs of entries that currently exist in the DB (excluding local instance entries)
+    # IDs of entries that currently exist in the DB
     found_ids = {entry.id for entry in entries_to_process}
-    # Account for entries filtered out cuz they're from this instance
-    local_ids = set(
-        Entry.objects.filter(
-            id__in=recently_touched_ids, originating_scram_instance=settings.SCRAM_HOSTNAME
-        ).values_list("id", flat=True)
-    )
     # IDs with history but no corresponding Entry row = orphaned (hard-deleted outside of Entry.delete())
-    orphaned_ids = recently_touched_ids - found_ids - local_ids
+    orphaned_ids = recently_touched_ids - found_ids
     if orphaned_ids:
         logger.warning("Found history records with no corresponding Entry: %s", orphaned_ids)
 


### PR DESCRIPTION
To clean things up, at the cost of negligible resources, we now reprocess updates regardless of which host it came from, to ensure consistency and fix a bug where we were assuming that the instance a block was created on is the instance a block will be deactivated from.