### PR TITLE
chore(containers): update container versions

### DIFF
--- a/compose.override.production.yml
+++ b/compose.override.production.yml
@@ -40,7 +40,7 @@ services:
       replicas: ${POSTGRES_ENABLED:-0}
 
   nginx:
-    image: nginx:1.19
+    image: nginx:1.31.1
     logging:
       driver: journald
       options:

--- a/compose.yml
+++ b/compose.yml
@@ -65,7 +65,7 @@ services:
       replicas: ${POSTGRES_ENABLED:-0}
 
   redis:
-    image: redis:8.2.2
+    image: redis:8.6
     networks:
       default: {}
     sysctls:
@@ -87,7 +87,7 @@ services:
       replicas: ${GOBGP_REPLICAS:-1}
 
   gobgp-secondary:
-    image: jauderho/gobgp:v3.33.0
+    image: jauderho/gobgp:v3.37.0
     networks:
       default: {}
     sysctls:


### PR DESCRIPTION
nginx had the vulnerability that just hit the news, gobgp secondary didn't match primary, and redis could use an update as well.